### PR TITLE
fix getStaticPaths() warning

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -16,6 +16,7 @@ const { title = 'Astro Crash Course' } = Astro.props as Props;
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="/favicon.svg" sizes="any" type="image/svg+xml">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
[slug].astro is capturing all urls and /favicon.ico is hitting that path without being satisfied. Actually in the project there was a favicon but .svg not .ico, so I fixed it with the following line in the layout
has been subject of Astro support post
https://discord.com/channels/830184174198718474/1050972818872995870
here the fix on a gitpod
https://violet-harrier-w1dqsjn81sh.ws-eu78.gitpod.io/